### PR TITLE
fix: remove unused typeclass instances

### DIFF
--- a/GibbsMeasure/Prereqs/Kernel/CondExp.lean
+++ b/GibbsMeasure/Prereqs/Kernel/CondExp.lean
@@ -22,7 +22,7 @@ lemma isCondExp_iff_bind_eq_left (hπ : π.IsProper) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
   · rw [hπ.setLIntegral_eq_comp h𝓑𝓧 hA hB, eq_comm]
     exact h _ (by measurability)
 
-lemma condExp_ae_eq_kernel_apply [IsFiniteMeasure μ] [IsFiniteKernel π]
+lemma condExp_ae_eq_kernel_apply
     (h : ∀ (f : X → ℝ), Bornology.IsBounded (Set.range f) → Measurable[𝓧] f →
       condExp 𝓑 μ f =ᵐ[μ] (fun x₀ ↦ ∫ x, f x ∂(π x₀)))
     {A : Set X} (A_mble : MeasurableSet[𝓧] A) :

--- a/GibbsMeasure/Specification.lean
+++ b/GibbsMeasure/Specification.lean
@@ -139,7 +139,7 @@ of the specification `γ`. -/
 def IsGibbsMeasure (γ : Specification S E) (μ : Measure (S → E)) : Prop := ∀ Λ, (γ Λ).IsCondExp μ
 
 -- The following two lemmas should generalise to a family of kernels indexed by a filtration
-lemma isGibbsMeasure_iff_forall_bind_eq (hγ : γ.IsProper) [IsFiniteMeasure μ] [IsMarkov γ] :
+lemma isGibbsMeasure_iff_forall_bind_eq (hγ : γ.IsProper) [IsFiniteMeasure μ] :
     γ.IsGibbsMeasure μ ↔ ∀ Λ, μ.bind (γ Λ) = μ :=
   forall_congr' fun _Λ ↦ Kernel.isCondExp_iff_bind_eq_left (hγ _) cylinderEvents_le_pi
 


### PR DESCRIPTION
## Summary
Remove unused typeclass instances from two lemmas.

## Details
The `unusedArguments` linter flagged:
1. `IsFiniteMeasure` and `IsFiniteKernel` instances in `condExp_ae_eq_kernel_apply` - the proof doesn't use them
2. `IsMarkov` instance in `isGibbsMeasure_iff_forall_bind_eq` - the proof doesn't use it

## Test plan
- ✅ Built `GibbsMeasure.Prereqs.Kernel.CondExp` successfully
- ✅ Built `GibbsMeasure.Specification` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)