### PR TITLE
feat(CondExp): fill in a slightly weaker sorry

### DIFF
--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -5,37 +5,17 @@ public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 
 public section
 
-open TopologicalSpace MeasureTheory.Lp Filter
+open TopologicalSpace MeasureTheory Lp Filter Measure Integrable
 open scoped ENNReal Topology MeasureTheory
 
 namespace MeasureTheory
 variable {α F F' 𝕜 : Type*} {p : ℝ≥0∞} [RCLike 𝕜]
-  [NormedAddCommGroup F]
-  [NormedSpace 𝕜 F]
-  [NormedAddCommGroup F']
-  [NormedSpace 𝕜 F'] [NormedSpace ℝ F'] [CompleteSpace F']
-
-variable {m m0 : MeasurableSpace α} {μ : Measure α} {f g : α → F'} {s : Set α}
-
--- /-- **Uniqueness of the conditional expectation**
--- If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral
--- as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
--- theorem toReal_ae_eq_condExp_toReal_of_forall_setLIntegral_eq (hm : m ≤ m0)
---     [SigmaFinite (μ.trim hm)] {f g : α → ℝ≥0∞} (hf_meas : AEMeasurable f μ)
---     (hf : ∫⁻ a, f a ∂μ ≠ ⊤)
---     (hg_int_finite : ∀ s, MeasurableSet[m] s → μ s < ∞ → ∫⁻ a in s, g a ∂μ ≠ ⊤)
---     (hg_eq : ∀ s : Set α, MeasurableSet[m] s → μ s < ∞ → ∫⁻ x in s, g x ∂μ = ∫⁻ x in s, f x ∂μ)
---     (hgm : AEStronglyMeasurable[m] g μ) :
---     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[fun a ↦ (f a).toReal|m] := by
---   refine ae_eq_condExp_of_forall_setIntegral_eq hm
---     (integrable_toReal_of_lintegral_ne_top hf_meas hf)
---     (fun s hs hs_fin ↦ integrable_toReal_of_lintegral_ne_top _ _) _ _
-
-open Measure Integrable
-
-variable [IsFiniteMeasure μ]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] [NormedSpace ℝ F'] [CompleteSpace F']
+  {m m0 : MeasurableSpace α} {μ : Measure α} {f g : α → F'} {s : Set α}
 
 --TODO : Generalise to SigmaFinite (μ.trim hm) ?
+variable [IsFiniteMeasure μ]
 
 /-- **Uniqueness of the conditional expectation**
 If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -1,6 +1,7 @@
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+public import GibbsMeasure.Mathlib.MeasureTheory.Integral.IntegrableOn
 
 public section
 
@@ -30,15 +31,36 @@ variable {m m0 : MeasurableSpace α} {μ : Measure α} {f g : α → F'} {s : Se
 --     (integrable_toReal_of_lintegral_ne_top hf_meas hf)
 --     (fun s hs hs_fin ↦ integrable_toReal_of_lintegral_ne_top _ _) _ _
 
+open Measure Integrable
+
+variable [IsFiniteMeasure μ] {g : α → ℝ≥0∞}
+
+--TODO : Generalise to SigmaFinite (μ.trim hm) ?
+
 /-- **Uniqueness of the conditional expectation**
 If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral
 as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
 theorem toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq (hm : m ≤ m0)
-    [SigmaFinite (μ.trim hm)] {g : α → ℝ≥0∞} {s : Set α} (hs : μ s ≠ ⊤)
+    {s : Set α} (hs₀ : MeasurableSet[m] s) (hgm : AEStronglyMeasurable[m] g μ)
     (hg_int_finite : ∀ t, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ ≠ ⊤)
-    (hg_eq : ∀ t : Set α, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t))
-    (hgm : AEStronglyMeasurable[m] g μ) : (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1|m] := by
-  refine ae_eq_condExp_of_forall_setIntegral_eq hm ?_ ?_ ?_ ?_ <;> sorry
+    (hg_eq : ∀ t : Set α, MeasurableSet[m0] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t)) :
+    (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1|m] := by
+  have : AEStronglyMeasurable[m0] g μ  := (hgm.mono hm).aemeasurable.aestronglyMeasurable
+  refine ae_eq_condExp_of_forall_setIntegral_eq (f := (s.indicator fun _ ↦ (1 : ℝ)))
+    hm (by fun_prop (disch := measurability)) (by fun_prop (disch := measurability))
+    (fun t ht hμt ↦ ?_) ?_
+  · have hg_ae : ∀ᵐ x ∂μ.restrict t, g x < ∞ := ae_lt_top'
+      (AEMeasurable.restrict (hgm.mono hm).aemeasurable)
+        (by simpa [Measure.restrict_restrict (hm _ ht)] using hg_int_finite t ht hμt)
+    calc
+      ∫ x in t, (g x).toReal ∂μ = ∫ x in t ∩ s, (1 : ℝ) ∂μ := by
+        simp [integral_toReal (AEMeasurable.restrict (hgm.mono hm).aemeasurable) hg_ae,
+          hg_eq t (hm t ht) hμt,measureReal_def _ _, Set.inter_comm s t, smul_eq_mul, mul_one]
+      _ = ∫ x in t, (s.indicator fun _ : α => (1 : ℝ)) x ∂μ := by
+            rw [← setIntegral_indicator (s := t) (μ := μ) (hm s hs₀)]
+  · exact (stronglyMeasurable_iff_measurable.2
+    (Measurable.ennreal_toReal hgm.stronglyMeasurable_mk.measurable)).aestronglyMeasurable.congr
+      (EventuallyEq.fun_comp hgm.ae_eq_mk ENNReal.toReal).symm
 
 lemma toReal_ae_eq_indicator_condExp_iff_forall_meas_inter_eq (hm : m ≤ m0)
     [SigmaFinite (μ.trim hm)] {g : α → ℝ≥0∞} {s : Set α} :

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -45,7 +45,7 @@ theorem toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq (hm : m ≤ m0)
     (hg_int_finite : ∀ t, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ ≠ ⊤)
     (hg_eq : ∀ t : Set α, MeasurableSet[m0] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t)) :
     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1|m] := by
-  have : AEStronglyMeasurable[m0] g μ := (hgm.mono hm).aemeasurable.aestronglyMeasurable
+  have : AEStronglyMeasurable[m0] g μ := hgm.mono hm
   refine ae_eq_condExp_of_forall_setIntegral_eq (f := (s.indicator fun _ ↦ (1 : ℝ)))
     hm (by fun_prop (disch := measurability)) (by fun_prop (disch := measurability))
     (fun t ht hμt ↦ ?_) ?_

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -1,7 +1,7 @@
 module
 
-public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 public import GibbsMeasure.Mathlib.MeasureTheory.Integral.IntegrableOn
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 
 public section
 
@@ -43,24 +43,23 @@ as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
 theorem toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq (hm : m ≤ m0)
     {g : α → ℝ≥0∞} {s : Set α} (hs₀ : MeasurableSet[m] s) (hgm : AEStronglyMeasurable[m] g μ)
     (hg_int_finite : ∀ t, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ ≠ ⊤)
-    (hg_eq : ∀ t : Set α, MeasurableSet[m0] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t)) :
+    (hg_eq : ∀ t : Set α, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t)) :
     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1|m] := by
   have : AEStronglyMeasurable[m0] g μ := hgm.mono hm
-  refine ae_eq_condExp_of_forall_setIntegral_eq (f := (s.indicator fun _ ↦ (1 : ℝ)))
-    hm (by fun_prop (disch := measurability)) (by fun_prop (disch := measurability))
+  refine ae_eq_condExp_of_forall_setIntegral_eq (f := s.indicator fun _ ↦ (1 : ℝ))
+    hm (by fun_prop (disch := measurability))
+    (fun t ht hμt ↦ integrableOn_toReal _ hm hgm fun t ht hμt ↦ by rw [hg_eq _ ht hμt]; finiteness)
     (fun t ht hμt ↦ ?_) ?_
-  · have hg_ae : ∀ᵐ x ∂μ.restrict t, g x < ∞ := ae_lt_top'
-      (AEMeasurable.restrict (hgm.mono hm).aemeasurable)
-        (by simpa [Measure.restrict_restrict (hm _ ht)] using hg_int_finite t ht hμt)
+  · have hg_ae : ∀ᵐ x ∂μ.restrict t, g x < ∞ := ae_lt_top' (hgm.mono hm).aemeasurable.restrict
+      (by simpa [Measure.restrict_restrict (hm _ ht)] using hg_int_finite t ht hμt)
     calc
       ∫ x in t, (g x).toReal ∂μ = ∫ x in t ∩ s, (1 : ℝ) ∂μ := by
-        simp [integral_toReal (AEMeasurable.restrict (hgm.mono hm).aemeasurable) hg_ae,
-          hg_eq t (hm t ht) hμt,measureReal_def _ _, Set.inter_comm s t, smul_eq_mul, mul_one]
-      _ = ∫ x in t, (s.indicator fun _ : α => (1 : ℝ)) x ∂μ := by
-            rw [← setIntegral_indicator (s := t) (μ := μ) (hm s hs₀)]
-  · exact (stronglyMeasurable_iff_measurable.2
-    (Measurable.ennreal_toReal hgm.stronglyMeasurable_mk.measurable)).aestronglyMeasurable.congr
-      (EventuallyEq.fun_comp hgm.ae_eq_mk ENNReal.toReal).symm
+        simp [integral_toReal (hgm.mono hm).aemeasurable.restrict hg_ae, hg_eq t ht hμt,
+          measureReal_def, Set.inter_comm]
+      _ = ∫ x in t, s.indicator (fun _ : α => (1 : ℝ)) x ∂μ := by
+        rw [← setIntegral_indicator (hm s hs₀)]
+  · exact hgm.stronglyMeasurable_mk.measurable.ennreal_toReal.aestronglyMeasurable.congr
+      (hgm.ae_eq_mk.fun_comp ENNReal.toReal).symm
 
 lemma toReal_ae_eq_indicator_condExp_iff_forall_meas_inter_eq (hm : m ≤ m0)
     [SigmaFinite (μ.trim hm)] {g : α → ℝ≥0∞} {s : Set α} :

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -5,8 +5,7 @@ public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 
 public section
 
-open TopologicalSpace MeasureTheory Lp Filter Measure Integrable
-open scoped ENNReal Topology MeasureTheory
+open scoped ENNReal
 
 namespace MeasureTheory
 variable {α F F' 𝕜 : Type*} {p : ℝ≥0∞} [RCLike 𝕜]

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -33,7 +33,7 @@ variable {m m0 : MeasurableSpace α} {μ : Measure α} {f g : α → F'} {s : Se
 
 open Measure Integrable
 
-variable [IsFiniteMeasure μ] {g : α → ℝ≥0∞}
+variable [IsFiniteMeasure μ]
 
 --TODO : Generalise to SigmaFinite (μ.trim hm) ?
 
@@ -41,11 +41,11 @@ variable [IsFiniteMeasure μ] {g : α → ℝ≥0∞}
 If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral
 as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
 theorem toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq (hm : m ≤ m0)
-    {s : Set α} (hs₀ : MeasurableSet[m] s) (hgm : AEStronglyMeasurable[m] g μ)
+    {g : α → ℝ≥0∞} {s : Set α} (hs₀ : MeasurableSet[m] s) (hgm : AEStronglyMeasurable[m] g μ)
     (hg_int_finite : ∀ t, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ ≠ ⊤)
     (hg_eq : ∀ t : Set α, MeasurableSet[m0] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ = μ (s ∩ t)) :
     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1|m] := by
-  have : AEStronglyMeasurable[m0] g μ  := (hgm.mono hm).aemeasurable.aestronglyMeasurable
+  have : AEStronglyMeasurable[m0] g μ := (hgm.mono hm).aemeasurable.aestronglyMeasurable
   refine ae_eq_condExp_of_forall_setIntegral_eq (f := (s.indicator fun _ ↦ (1 : ℝ)))
     hm (by fun_prop (disch := measurability)) (by fun_prop (disch := measurability))
     (fun t ht hμt ↦ ?_) ?_

--- a/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -41,6 +41,20 @@ theorem toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq (hm : m ≤ m0)
   · exact hgm.stronglyMeasurable_mk.measurable.ennreal_toReal.aestronglyMeasurable.congr
       (hgm.ae_eq_mk.fun_comp ENNReal.toReal).symm
 
+-- /-- **Uniqueness of the conditional expectation**
+-- If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral
+-- as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
+-- theorem toReal_ae_eq_condExp_toReal_of_forall_setLIntegral_eq (hm : m ≤ m0)
+--     [SigmaFinite (μ.trim hm)] {f g : α → ℝ≥0∞} (hf_meas : AEMeasurable f μ)
+--     (hf : ∫⁻ a, f a ∂μ ≠ ⊤)
+--     (hg_int_finite : ∀ s, MeasurableSet[m] s → μ s < ∞ → ∫⁻ a in s, g a ∂μ ≠ ⊤)
+--     (hg_eq : ∀ s : Set α, MeasurableSet[m] s → μ s < ∞ → ∫⁻ x in s, g x ∂μ = ∫⁻ x in s, f x ∂μ)
+--     (hgm : AEStronglyMeasurable[m] g μ) :
+--     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[fun a ↦ (f a).toReal|m] := by
+--   refine ae_eq_condExp_of_forall_setIntegral_eq hm
+--     (integrable_toReal_of_lintegral_ne_top hf_meas hf)
+--     (fun s hs hs_fin ↦ integrable_toReal_of_lintegral_ne_top _ _) _ _
+
 lemma toReal_ae_eq_indicator_condExp_iff_forall_meas_inter_eq (hm : m ≤ m0)
     [SigmaFinite (μ.trim hm)] {g : α → ℝ≥0∞} {s : Set α} :
     (fun a ↦ (g a).toReal) =ᵐ[μ] μ[s.indicator 1| m] ↔

--- a/GibbsMeasure/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -2,9 +2,6 @@ module
 
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
-
-
-
 open ENNReal MeasureTheory Integrable
 
 attribute [fun_prop] MeasureTheory.IntegrableOn

--- a/GibbsMeasure/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/GibbsMeasure/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -1,0 +1,20 @@
+module
+
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+
+
+
+open ENNReal MeasureTheory Integrable
+
+attribute [fun_prop] MeasureTheory.IntegrableOn
+
+variable {α : Type*} {m m0 : MeasurableSpace α} {μ : Measure α} {s : Set α}
+[IsFiniteMeasure μ] {g : α → ℝ≥0∞}
+
+@[fun_prop]
+public lemma integrableOn_toReal (t : Set α) (hm : m ≤ m0) (hgm : AEStronglyMeasurable[m] g μ)
+   (hg_int_finite : ∀ t, MeasurableSet[m] t → μ t < ∞ → ∫⁻ a in t, g a ∂μ ≠ ⊤) :
+  IntegrableOn (fun x ↦ (g x).toReal) t μ :=
+    integrableOn (s := t) <| integrable_toReal_of_lintegral_ne_top (hgm.mono hm).aemeasurable <|
+      by simpa using hg_int_finite Set.univ (by simp) (by simp)

--- a/GibbsMeasure/Prereqs/Kernel/CondExp.lean
+++ b/GibbsMeasure/Prereqs/Kernel/CondExp.lean
@@ -16,7 +16,7 @@ class IsCondExp (π : Kernel[𝓑, 𝓧] X X) (μ : Measure[𝓧] X) : Prop wher
   condExp_ae_eq_kernel_apply ⦃A : Set X⦄ : MeasurableSet[𝓧] A →
     μ[A.indicator 1| 𝓑] =ᵐ[μ] fun a ↦ (π a A).toReal
 
-lemma isCondExp_iff_bind_eq_left (hπ : π.IsProper) (h𝓑𝓧 : 𝓑 ≤ 𝓧) [SigmaFinite (μ.trim h𝓑𝓧)] :
+lemma isCondExp_iff_bind_eq_left (hπ : π.IsProper) (h𝓑𝓧 : 𝓑 ≤ 𝓧) [IsFiniteMeasure μ] :
     IsCondExp π μ ↔ μ.bind π = μ := by
   simp_rw [isCondExp_iff, Filter.eventuallyEq_comm,
     toReal_ae_eq_indicator_condExp_iff_forall_meas_inter_eq h𝓑𝓧, Measure.ext_iff]


### PR DESCRIPTION
Fill in a slightly weaker version of `toReal_ae_eq_indicator_condExp_of_forall_setLIntegral_eq` and add a TODO to generalise it.